### PR TITLE
Use service_name instead of node_name when creating service files

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The `etcd_service` resource property list corresponds to the options found in
 - `discovery_srv`
 - `discovery_fallback`
 - `discovery_proxy`
+- `strict_reconfig_check`
 
 ##### Proxy Flags
 

--- a/libraries/etcd_service_base.rb
+++ b/libraries/etcd_service_base.rb
@@ -16,9 +16,10 @@ module EtcdCookbook
 
     # https://coreos.com/etcd/docs/latest/configuration.html
     # Member flags
-    property :node_name, String, name_property: true, desired_state: false
-    property :data_dir, String, default: lazy { "#{node_name}.etcd" }, desired_state: false
+    property :service_name, String, name_property: true, desired_state: false
+    property :data_dir, String, default: lazy { "#{service_name}.etcd" }, desired_state: false
     property :wal_dir, String, desired_state: false
+    property :node_name, String, default: lazy { "#{service_name}" }, desired_state: false
     property :snapshot_count, String, desired_state: false
     property :heartbeat_interval, String, desired_state: false
     property :election_timeout, String, desired_state: false

--- a/libraries/etcd_service_base.rb
+++ b/libraries/etcd_service_base.rb
@@ -40,6 +40,7 @@ module EtcdCookbook
     property :discovery_srv, String, desired_state: false
     property :discovery_fallback, String, desired_state: false
     property :discovery_proxy, String, desired_state: false
+    property :strict_reconfig_check, Boolean, default: false, desired_state: false
 
     # Proxy Flags
     property :proxy, String, desired_state: false

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -52,8 +52,9 @@ module EtcdCookbook
         opts
       end
 
+
       def etcd_name
-        "etcd-#{node_name}"
+        "etcd-#{service_name}"
       end
 
       def etcdctl_bin

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -49,6 +49,7 @@ module EtcdCookbook
         opts << "-snapshot-count=#{snapshot_count}" unless snapshot_count.nil?
         opts << "-trusted-ca-file=#{trusted_ca_file}" unless trusted_ca_file.nil?
         opts << "-wal-dir=#{wal_dir}" unless wal_dir.nil?
+        opts << '-strict-reconfig-check=true' if strict_reconfig_check == true
         opts
       end
 

--- a/templates/default/sysvinit/etcd.erb
+++ b/templates/default/sysvinit/etcd.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides:          etcd
+# Provides:          <%= @etcd_name %>
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Should-Start:      $network $time


### PR DESCRIPTION
Add a new property `service_name` to avoid using node name for naming service files 